### PR TITLE
Add link to frame & store documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ can be seen below. It is best to create one SLING document per input sentence.
   }
 }
 ```
+For writing your converter or getting better hold of concept of frames and store in SLING, you can have a look at detailed deep dive on frames and stores [here](sling/frame/README.md).
 
 The SLING [Document class](sling/nlp/document/document.h)
 also has methods to incrementally make such document frames, e.g.


### PR DESCRIPTION
Frame and store are very lightly touched in Sling root readme file making them tougher to fully comprehend. The link would help better understanding needed for training your own models.